### PR TITLE
add skill delete even with chall + workplanskill + results attached

### DIFF
--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -3,7 +3,8 @@
 class Skill < ApplicationRecord
   belongs_to :school
   belongs_to :domain
-  has_many :work_plan_skills, dependent: nil
+  has_many :work_plan_skills, dependent: :destroy
+  has_many :results, dependent: :destroy
   has_many :challenges, dependent: :destroy
   acts_as_list scope: [:domain_id, :level]
 

--- a/app/views/skills/_skill.html.erb
+++ b/app/views/skills/_skill.html.erb
@@ -15,7 +15,7 @@
         <% end %>
         <%= button_to skill_path(skill), method: :delete,
           class:'--bgc-blanc',
-          data:{ turbo_confirm: "Souhaitez vous effacer cette compétence?"} do %>
+          data:{ turbo_confirm: "Souhaitez vous effacer cette compétence? \nATTENTION en supprimant cette compétence, vous allez EFFACER:\n-TOUS les éléments des plans de travail existants liés à cette compétence.\n-TOUTES les EVALUATIONS pour tous les élèves du niveau sur cette compétence.\n-TOUS les EXCERCICES liés."} do %>
           <div class='rmv-skill-btn'>
             <i class="far fa-times-circle"></i>
           </div>


### PR DESCRIPTION
This pull request makes changes to the `Skill` model and its associated view to improve data consistency and provide clearer user warnings about the consequences of deleting a skill. The most important changes include updating associations in the `Skill` model and enhancing the confirmation message in the skill deletion button.

### Model changes:

* [`app/models/skill.rb`](diffhunk://#diff-aa00625551ea77a6f1c6fa6c4a7cc33f4b7cb1ec8cea2e2af8b816fa2a4dcea5L6-R7): Updated the `has_many` associations for `work_plan_skills` and added new associations for `results` and `challenges`, all with `dependent: :destroy`. This ensures that related records are automatically removed when a `Skill` is deleted, improving data consistency.

### View changes:

* [`app/views/skills/_skill.html.erb`](diffhunk://#diff-ce317b421d076b354925d12d28997e72e7f5cf83634d860da14b8de02f09a324L18-R18): Enhanced the `turbo_confirm` message in the skill deletion button to provide a detailed warning about the impact of deleting a skill, including the removal of related work plan elements, evaluations, and exercises. This helps users make informed decisions.