### PR TITLE
chnage policy

### DIFF
--- a/app/policies/challenge_policy.rb
+++ b/app/policies/challenge_policy.rb
@@ -39,7 +39,7 @@ class ChallengePolicy < ApplicationPolicy
   def destroy?
     user_can_destroy? && challenge_not_used?
   end
-  
+
   def can_show_delete_button?
     user_can_destroy? && challenge_not_used?
   end
@@ -51,7 +51,7 @@ class ChallengePolicy < ApplicationPolicy
   end
 
   def user_can_destroy?
-    record.user == user || user.admin? || record.user.admin?
+    record.skill.school == user.school || user.admin? || record.user.admin?
   end
 
   def challenge_not_used?


### PR DESCRIPTION
This pull request updates the `user_can_destroy?` method in the `ChallengePolicy` class to refine the conditions under which a user can destroy a challenge.

Policy logic update:

* [`app/policies/challenge_policy.rb`](diffhunk://#diff-e997b17b93fac4c0c023eb13ba38a8c424f52f3378a3d2c210833e3da17b971fL54-R54): Modified the `user_can_destroy?` method to check if the `record`'s associated `skill.school` matches the `user.school`, ensuring that only users within the same school or with admin privileges can destroy a challenge.