### PR TITLE
remove trix editor pink background color

### DIFF
--- a/app/assets/stylesheets/components/_actiontext.scss
+++ b/app/assets/stylesheets/components/_actiontext.scss
@@ -46,7 +46,7 @@
 }
 
 trix-editor {
-  background-color: rgba(250, 128, 114, 0.308);
+  background-color: none;
   padding: 0 !important;
 }
 .trix-button-group--text-tools {


### PR DESCRIPTION
This pull request makes a minor update to the styling of the `trix-editor` component by removing its custom background color. This change will allow the editor to inherit its background from parent elements or default styles, rather than using a semi-transparent salmon color.

* Removed the `background-color` property from the `trix-editor` selector in `_actiontext.scss`, setting it to `none` instead of a semi-transparent color.