### PR TITLE
fix: share single Ferrum browser across batch PDF generation

### DIFF
--- a/app/jobs/generate_results_classroom_pdfs_job.rb
+++ b/app/jobs/generate_results_classroom_pdfs_job.rb
@@ -15,10 +15,12 @@ class GenerateResultsClassroomPdfsJob < ApplicationJob
       Rails.logger.info("Created empty zip file at #{temp_file.path}")
       # Open the zip file and add a PDF for each student
       Zip::File.open(temp_file.path, Zip::File::CREATE) do |zipfile|
-        students.each do |student|
-          pdf = PdfGenerator::StudentResultPdf.new(student).generate
-          zipfile.get_output_stream("Progression de #{I18n.transliterate(student.first_name).capitalize}_#{Time.current.strftime('_%Y_%m_%d')}.pdf") do |f|
-            f.write(pdf)
+        PdfGenerator.with_browser do |browser|
+          students.each do |student|
+            pdf = PdfGenerator::StudentResultPdf.new(student).with_browser(browser).generate
+            zipfile.get_output_stream("Progression de #{I18n.transliterate(student.first_name).capitalize}_#{Time.current.strftime('_%Y_%m_%d')}.pdf") do |f|
+              f.write(pdf)
+            end
           end
         end
       end

--- a/app/modules/pdf_generator.rb
+++ b/app/modules/pdf_generator.rb
@@ -9,9 +9,39 @@ module PdfGenerator
     end
   end
 
+  # Crée un browser Ferrum partageable pour générer plusieurs PDFs
+  def self.create_browser
+    Ferrum::Browser.new(
+      browser_path: CHROME_PATH,
+      headless: true,
+      timeout: 60,
+      process_timeout: 30,
+      browser_options: {
+        "no-sandbox": true,
+        "disable-setuid-sandbox": true,
+        "disable-dev-shm-usage": true
+      }
+    )
+  end
+
+  # Exécute un bloc avec un browser partagé, puis le ferme proprement
+  def self.with_browser
+    browser = create_browser
+    yield browser
+  ensure
+    browser&.quit
+  end
+
   class Base
     def initialize(layout = "pdf.html")
       @layout = layout
+      @shared_browser = nil
+    end
+
+    # Permet d'injecter un browser partagé pour les générations en lot
+    def with_browser(browser)
+      @shared_browser = browser
+      self
     end
 
     # Méthode abstraite qui sera implémentée par les classes dérivées
@@ -24,48 +54,49 @@ module PdfGenerator
     # Génère un PDF à partir de HTML en utilisant Ferrum
     # Les marges sont en pouces (inches) pour Ferrum
     def html_to_pdf(html, options = {})
-      browser = Ferrum::Browser.new(
-        browser_path: CHROME_PATH,
-        headless: true,
-        timeout: 60,
-        process_timeout: 30,
-        browser_options: {
-          "no-sandbox": true,
-          "disable-setuid-sandbox": true,
-          "disable-dev-shm-usage": true
-        }
-      )
-
-      begin
-        page = browser.create_page
-        page.content = html
-
-        # Attendre que le contenu soit chargé
-        page.network.wait_for_idle
-
-        # Marges en pouces (1 inch = 25.4mm)
-        pdf_options = {
-          format: :A4,
-          print_background: true,
-          margin_top: options[:margin_top] || 0.3,
-          margin_bottom: options[:margin_bottom] || 0.3,
-          margin_left: options[:margin_left] || 0.2,
-          margin_right: options[:margin_right] || 0.2
-        }
-
-        # Ajouter header/footer si spécifié
-        if options[:display_header_footer]
-          pdf_options[:display_header_footer] = true
-          pdf_options[:header_template] = options[:header_template] || "<span></span>"
-          pdf_options[:footer_template] = options[:footer_template] || "<span></span>"
+      if @shared_browser
+        generate_pdf_with_browser(@shared_browser, html, options)
+      else
+        browser = PdfGenerator.create_browser
+        begin
+          generate_pdf_with_browser(browser, html, options)
+        ensure
+          browser.quit
         end
-
-        pdf_data = page.pdf(**pdf_options)
-        # Ferrum retourne le PDF en base64, il faut le décoder
-        Base64.decode64(pdf_data)
-      ensure
-        browser.quit
       end
+    end
+
+    private
+
+    def generate_pdf_with_browser(browser, html, options)
+      page = browser.create_page
+      page.content = html
+
+      # Attendre que le contenu soit chargé
+      page.network.wait_for_idle
+
+      # Marges en pouces (1 inch = 25.4mm)
+      pdf_options = {
+        format: :A4,
+        print_background: true,
+        margin_top: options[:margin_top] || 0.3,
+        margin_bottom: options[:margin_bottom] || 0.3,
+        margin_left: options[:margin_left] || 0.2,
+        margin_right: options[:margin_right] || 0.2
+      }
+
+      # Ajouter header/footer si spécifié
+      if options[:display_header_footer]
+        pdf_options[:display_header_footer] = true
+        pdf_options[:header_template] = options[:header_template] || "<span></span>"
+        pdf_options[:footer_template] = options[:footer_template] || "<span></span>"
+      end
+
+      pdf_data = page.pdf(**pdf_options)
+      # Ferrum retourne le PDF en base64, il faut le décoder
+      Base64.decode64(pdf_data)
+    ensure
+      page&.close
     end
   end
 end


### PR DESCRIPTION
The classroom PDF job was launching a new Chrome process for each student, causing slowness and memory exhaustion. Now reuses a single browser instance for all students, with proper page cleanup between generations.